### PR TITLE
fix astropy to work with split imperial units

### DIFF
--- a/benchmarks/bench_astropy.py
+++ b/benchmarks/bench_astropy.py
@@ -1,5 +1,6 @@
 import numpy as np
 import astropy.units
+import astropy.units.imperial
 
 import base
 
@@ -23,7 +24,10 @@ class BenchAstropy(base.BenchModule):
         return "multiply"
 
     def make(self, ndarray, units):
-        return getattr(astropy.units, units) * ndarray
+        try:
+            return getattr(astropy.units, units) * ndarray
+        except:
+            return getattr(astropy.units.imperial, units) * ndarray
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The tests don't work with the most recent version of astropy.  This pull requests fixes the problem.
